### PR TITLE
Fix loggertest carriage return windows and add different ports in test.

### DIFF
--- a/backend/src/test/java/com/benine/backend/LoggerTest.java
+++ b/backend/src/test/java/com/benine/backend/LoggerTest.java
@@ -34,7 +34,7 @@ public class LoggerTest {
   public void testLogToConsole() {
     Logger logger = new Logger(logwriter);
     logger.log("this moment", "Hello", LogEvent.Type.CRITICAL);
-    Assert.assertEquals("[CRITICAL|this moment]Hello\n", out.toString());
+    Assert.assertEquals("[CRITICAL|this moment]Hello" + System.lineSeparator(), out.toString());
     out.reset();
   }
 
@@ -84,7 +84,7 @@ public class LoggerTest {
     logger.disableConsoleLogging();
     logger.enableConsoleLogging();
     logger.log("this moment", "Hello", LogEvent.Type.CRITICAL);
-    Assert.assertEquals("[CRITICAL|this moment]Hello\n", out.toString());
+    Assert.assertEquals("[CRITICAL|this moment]Hello" + System.lineSeparator(), out.toString());
     out.reset();
   }
 

--- a/backend/src/test/java/com/benine/backend/camera/ipcameracontrol/IpcameraFocusTest.java
+++ b/backend/src/test/java/com/benine/backend/camera/ipcameracontrol/IpcameraFocusTest.java
@@ -25,10 +25,10 @@ import com.benine.backend.camera.CameraConnectionException;
 public class IpcameraFocusTest {
   
   @Rule
-  public MockServerRule mockServerRule = new MockServerRule(this, 9000);
+  public MockServerRule mockServerRule = new MockServerRule(this, 9004);
 
   private MockServerClient mockServerClient;
-  private IPCamera camera = new IPCamera("127.0.0.1:9000");
+  private IPCamera camera = new IPCamera("127.0.0.1:9004");
 
   private ArrayList<Parameter> parameterList;
   

--- a/backend/src/test/java/com/benine/backend/camera/ipcameracontrol/IpcameraIrisTest.java
+++ b/backend/src/test/java/com/benine/backend/camera/ipcameracontrol/IpcameraIrisTest.java
@@ -25,10 +25,10 @@ import com.benine.backend.camera.CameraConnectionException;
 public class IpcameraIrisTest {
   
   @Rule
-  public MockServerRule mockServerRule = new MockServerRule(this, 9000);
+  public MockServerRule mockServerRule = new MockServerRule(this, 9003);
 
   private MockServerClient mockServerClient;
-  private IPCamera camera = new IPCamera("127.0.0.1:9000");
+  private IPCamera camera = new IPCamera("127.0.0.1:9003");
 
   private ArrayList<Parameter> parameterList;
   

--- a/backend/src/test/java/com/benine/backend/camera/ipcameracontrol/IpcameraTest.java
+++ b/backend/src/test/java/com/benine/backend/camera/ipcameracontrol/IpcameraTest.java
@@ -26,7 +26,7 @@ import java.util.ArrayList;
 public class IpcameraTest {
 
   @Rule
-  public MockServerRule mockServerRule = new MockServerRule(this, 9000);
+  public MockServerRule mockServerRule = new MockServerRule(this, 9002);
 
   private MockServerClient mockServerClient;
   private IPCamera camera;
@@ -36,7 +36,7 @@ public class IpcameraTest {
   @Before
   public final void setUp() throws InvalidCameraTypeException{
 	  IPCameraFactory factory = new IPCameraFactory();
-	  String[] camSpec = {"ipcamera", "127.0.0.1:9000"};
+	  String[] camSpec = {"ipcamera", "127.0.0.1:9002"};
 	  camera = factory.createCamera(camSpec);
   }
 
@@ -110,7 +110,7 @@ public class IpcameraTest {
     parameterList.add(new Parameter("cmd", "#D30"));
 
     String res = camera.getStreamLink();
-    assertEquals(res, "http://127.0.0.1:9000/cgi-bin/mjpeg");
+    assertEquals(res, "http://127.0.0.1:9002/cgi-bin/mjpeg");
   }
   
   @Test(expected = IpcameraConnectionException.class)

--- a/backend/src/test/java/com/benine/backend/camera/ipcameracontrol/IpcameraZoomTest.java
+++ b/backend/src/test/java/com/benine/backend/camera/ipcameracontrol/IpcameraZoomTest.java
@@ -23,10 +23,10 @@ import com.benine.backend.camera.CameraConnectionException;
 public class IpcameraZoomTest {
   
   @Rule
-  public MockServerRule mockServerRule = new MockServerRule(this, 9000);
+  public MockServerRule mockServerRule = new MockServerRule(this, 9001);
 
   private MockServerClient mockServerClient;
-  private IPCamera camera = new IPCamera("127.0.0.1:9000");
+  private IPCamera camera = new IPCamera("127.0.0.1:9001");
 
   private ArrayList<Parameter> parameterList;
   


### PR DESCRIPTION
On my windows machine the logger test gave an error which is now fixed.
Can you confirm it still works for you?

I changed the port numbers of the mocked test camera's, so they can't interfer.