### PR TITLE
NodeJS bridge api

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2,6 +2,7 @@ var path = require('path');
 
 var logger = require('./modules/logger');
 var config = require('./modules/config');
+var api = require('./modules/api');
 
 var express = require('express');
 var app = express();
@@ -17,18 +18,7 @@ app.get('/', function (req, res) {
     res.sendFile(path.join(__dirname + '/index.html'));
 });
 
-var api = new express.Router();
-
-// API call /api/getserver returns a JSON object with data about the backend server.
-api.get('/getserver', function (req, res) {
-    res.json(
-        {
-        address: config.get('backend_server'),
-        port: config.get('backend_port')
-        }
-    )
-});
-
+// Use the api module for all /api calls.
 app.use('/api', api);
 
 app.listen(config.get('server_port'), function () {

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -7,8 +7,6 @@ var api = require('./modules/api');
 var express = require('express');
 var app = express();
 
-console.log(config);
-
 app.use('/public', express.static(__dirname + '/public'));
 app.use('/bower_components', express.static(__dirname + '/bower_components'));
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -28,8 +28,7 @@
                 <a class="navbar-brand" href="#">PolyCast WebInterface</a>
             </div>
             <div class ="labelcontainer">
-                <span class="label label-success">Server Status</span>
-                <span class="label label-danger">Camera Conflict</span>
+                <span id="server_status" class="label label-warning">Server Status</span>
             </div>
 
         </div>

--- a/frontend/modules/api.js
+++ b/frontend/modules/api.js
@@ -1,10 +1,20 @@
 var express = require('express');
 var config = require('./config');
+var logger = require('./logger');
 var request = require('request');
 var router = express.Router();
 
 // Address of the backend server.
 var address = "http://" + config.get("backend_server") + ":" + config.get("backend_port");
+logger.logMessage(logger.levels.INFO, "Backend server address: " + address);
+
+/**
+ * Middleware to log every API request.
+ */
+router.use(function (req, res, next) {
+    logger.logMessage(logger.levels.INFO, "Received request: " + req.url);
+    next();
+})
 
 /**
  * First the NodeJS server's own API is defined.

--- a/frontend/modules/api.js
+++ b/frontend/modules/api.js
@@ -33,7 +33,15 @@ router.get('/getbackend', function (req, res) {
  * All /backend/... calls are rerouted to the backend server.
  */
 router.get('/backend/*', function (req, res) {
-    request(address + req.url).pipe(res);
+    request(address + req.url)
+        .on('error', function (err) {
+            // An error has occured, most likely the server has not been started.
+            if (err.code === 'ECONNREFUSED') {
+                logger.logMessage(logger.levels.ERROR, "Connection with back-end server failed.");
+            }
+        })
+        .pipe(res);
+
 });
 
 module.exports = router;

--- a/frontend/modules/api.js
+++ b/frontend/modules/api.js
@@ -1,0 +1,15 @@
+var express = require('express');
+var config = require('./config');
+var router = express.Router();
+
+// API call /api/getserver returns a JSON object with data about the backend server.
+router.get('/getserver', function (req, res) {
+    res.json(
+        {
+            address: config.get('backend_server'),
+            port: config.get('backend_port')
+        }
+    )
+});
+
+module.exports = router;

--- a/frontend/modules/api.js
+++ b/frontend/modules/api.js
@@ -1,15 +1,29 @@
 var express = require('express');
 var config = require('./config');
+var request = require('request');
 var router = express.Router();
 
-// API call /api/getserver returns a JSON object with data about the backend server.
-router.get('/getserver', function (req, res) {
+// Address of the backend server.
+var address = "http://" + config.get("backend_server") + ":" + config.get("backend_port");
+
+/**
+ * First the NodeJS server's own API is defined.
+ */
+// API call /api/getbackend returns a JSON object with data about the backend server.
+router.get('/getbackend', function (req, res) {
     res.json(
         {
             address: config.get('backend_server'),
             port: config.get('backend_port')
         }
     )
+});
+
+/**
+ * All /backend/... calls are rerouted to the backend server.
+ */
+router.get('/backend/*', function (req, res) {
+    request(address + req.url).pipe(res);
 });
 
 module.exports = router;

--- a/frontend/modules/api.js
+++ b/frontend/modules/api.js
@@ -14,19 +14,38 @@ logger.logMessage(logger.levels.INFO, "Backend server address: " + address);
 router.use(function (req, res, next) {
     logger.logMessage(logger.levels.INFO, "Received request: " + req.url);
     next();
-})
+});
+
+/**
+ * Reports the status of the backend server.
+ * @param callback  function accepting a string. (status)
+ */
+function backend_status(callback) {
+    request(address + '/')
+        .on('error', function() {
+            callback('offline');
+        })
+        .on('response', function () {
+            callback('online');
+        });
+}
 
 /**
  * First the NodeJS server's own API is defined.
  */
-// API call /api/getbackend returns a JSON object with data about the backend server.
-router.get('/getbackend', function (req, res) {
-    res.json(
-        {
-            address: config.get('backend_server'),
-            port: config.get('backend_port')
-        }
-    )
+// API call /api/getinfo returns a JSON object with info about the server.
+router.get('/getinfo', function (req, res) {
+    backend_status(function (status) {
+        res.json(
+            {
+                backend: {
+                    address: config.get('backend_server'),
+                    port: config.get('backend_port'),
+                    status: status
+                }
+            }
+        )
+    })
 });
 
 /**
@@ -35,9 +54,9 @@ router.get('/getbackend', function (req, res) {
 router.get('/backend/*', function (req, res) {
     request(address + req.url)
         .on('error', function (err) {
-            // An error has occured, most likely the server has not been started.
+            // An error has occurred, most likely the server has not been started.
             if (err.code === 'ECONNREFUSED') {
-                logger.logMessage(logger.levels.ERROR, "Connection with back-end server failed.");
+                logger.logMessage(logger.levels.ERROR, "Connection with back-end server failed, is the back-end server online?");
             }
         })
         .pipe(res);

--- a/frontend/public/js/generator.js
+++ b/frontend/public/js/generator.js
@@ -14,6 +14,9 @@ var presetcounter = 0;
 // Document is ready, we can now manipulate it.
 $(document).ready(function() {
 
+    // Update server status every 10 seconds.
+    setInterval(setServerStatus, 10 * 1000);
+
     // Generate the camera block area.
     generateCameraArea();
 
@@ -23,6 +26,19 @@ $(document).ready(function() {
     console.log('Page has loaded successfully.');
 
 });
+
+/**
+ * Sets the backend server status.
+ */
+function setServerStatus() {
+    $.get("http://localhost:3000/api/getinfo", function (data) {
+        if (data.backend.status === "online") {
+            $('#server_status').attr('class', 'label label-success');
+        } else {
+            $('#server_status').attr('class', 'label label-danger');
+        }
+    })
+}
 
 /**
  * Generates the camera area of the app.

--- a/frontend/public/js/generator.js
+++ b/frontend/public/js/generator.js
@@ -3,13 +3,13 @@ var cameracounter = 0;
 var blockcounter = 0;
 var presetcounter = 0;
 
-// Hold the ready until all data about the backend server is fetched.
-$.holdReady(true);
-
-$.get('http://localhost:3000/api/getserver', function(data) {
-    address = 'http://' + data.address + ':' + data.port;
-    $.holdReady(false);
-});
+// The document ready can be hold as follows, might additional data from the server be needed.
+// $.holdReady(true);
+//
+// $.get('http://localhost:3000/api/getserver', function(data) {
+//     address = 'http://' + data.address + ':' + data.port;
+//     $.holdReady(false);
+// });
 
 // Document is ready, we can now manipulate it.
 $(document).ready(function() {


### PR DESCRIPTION
This provides a new api for the NodeJS front-end.

`/api/getinfo` returns info about the backend server in JSON format.
`/api/*` sends `*` to the backend server and returns the response to the client acting as a bridge between the client and the backend server.

And example of the use of the API is implemented by giving the Server Status icon in the client its functionality.

This should fix #43 by removing the communication client →  backend by adding the front-end server as a bridge: client →  front-end →  back-end