### PR TITLE
MJPEG stream optimization

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>9.0.2.v20130417</version>
+            <version>9.3.9.v20160517</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/backend/src/main/java/com/benine/backend/http/CameraStreamHandler.java
+++ b/backend/src/main/java/com/benine/backend/http/CameraStreamHandler.java
@@ -56,7 +56,7 @@ public class CameraStreamHandler extends CameraRequestHandler {
           os.write(bytes, 0, bytesRead);
         }
       } catch (IOException e) {
-        System.out.println("ENDED");
+        // Outputstream closed, connection with client ended.
       } finally {
         os.close();
         in.close();

--- a/backend/src/main/java/com/benine/backend/http/CameraStreamHandler.java
+++ b/backend/src/main/java/com/benine/backend/http/CameraStreamHandler.java
@@ -49,15 +49,17 @@ public class CameraStreamHandler extends CameraRequestHandler {
 
       byte[] bytes = new byte[16384];
       int bytesRead;
-      boolean running = true;
 
       try {
-        while ((bytesRead = in.read(bytes)) != -1 && running) {
-            os.write(bytes, 0, bytesRead);
-            os.flush();
+        while ((bytesRead = in.read(bytes)) != -1) {
+          os.write(bytes, 0, bytesRead);
+          os.flush();
         }
       } catch (IOException e) {
-        getLogger().log("Client " + request.getRemoteAddr() + " disconnected from MJPEG stream " + camID, LogEvent.Type.INFO);
+        getLogger().log("Client "
+                + request.getRemoteAddr()
+                + " disconnected from MJPEG stream "
+                + camID, LogEvent.Type.INFO);
       } finally {
         os.close();
         in.close();
@@ -72,8 +74,9 @@ public class CameraStreamHandler extends CameraRequestHandler {
 
   /**
    * Sets the HTTP Headers so the browser detects MJPEG.
-   * @param reader                The MJPEG stream reader containing the boundary.
-   * @param httpServletResponse   The response for which the headers should be set.
+   *
+   * @param reader              The MJPEG stream reader containing the boundary.
+   * @param httpServletResponse The response for which the headers should be set.
    */
   private void setHeaders(MJPEGStreamReader reader, HttpServletResponse httpServletResponse) {
     httpServletResponse.setContentType(MJPEGHeader.CONTENT_TYPE.getContents()

--- a/backend/src/main/java/com/benine/backend/http/CameraStreamHandler.java
+++ b/backend/src/main/java/com/benine/backend/http/CameraStreamHandler.java
@@ -44,13 +44,13 @@ public class CameraStreamHandler extends CameraRequestHandler {
       setHeaders(streamReaderMJPEG, res);
 
       // Get an inputstream from the distributer.
-      PipedInputStream in = new PipedInputStream(distributer.getStream());
-      ServletOutputStream os = res.getOutputStream();
 
       byte[] bytes = new byte[16384];
       int bytesRead;
 
-      try {
+      try (PipedInputStream in = new PipedInputStream(distributer.getStream());
+           ServletOutputStream os = res.getOutputStream()) {
+
         while ((bytesRead = in.read(bytes)) != -1) {
           os.write(bytes, 0, bytesRead);
           os.flush();
@@ -60,9 +60,6 @@ public class CameraStreamHandler extends CameraRequestHandler {
                 + request.getRemoteAddr()
                 + " disconnected from MJPEG stream "
                 + camID, LogEvent.Type.INFO);
-      } finally {
-        os.close();
-        in.close();
       }
 
     } else {

--- a/backend/src/main/java/com/benine/backend/http/CameraStreamHandler.java
+++ b/backend/src/main/java/com/benine/backend/http/CameraStreamHandler.java
@@ -48,15 +48,15 @@ public class CameraStreamHandler extends CameraRequestHandler {
       PipedInputStream in = new PipedInputStream(distributer.getStream());
       OutputStream os = res.getOutputStream();
 
-      byte[] bytes = new byte[4096];
+      byte[] bytes = new byte[16384];
       int bytesRead;
 
       try {
         while ((bytesRead = in.read(bytes)) != -1) {
           os.write(bytes, 0, bytesRead);
         }
-      } catch (Exception e) {
-        e.printStackTrace();
+      } catch (IOException e) {
+        System.out.println("ENDED");
       } finally {
         os.close();
         in.close();
@@ -66,7 +66,6 @@ public class CameraStreamHandler extends CameraRequestHandler {
       res.setStatus(HttpServletResponse.SC_NOT_FOUND);
     }
 
-    System.out.println("TEST");
     request.setHandled(true);
   }
 

--- a/backend/src/main/java/com/benine/backend/http/CameraStreamHandler.java
+++ b/backend/src/main/java/com/benine/backend/http/CameraStreamHandler.java
@@ -10,7 +10,6 @@ import com.benine.backend.video.StreamReader;
 import com.benine.backend.video.StreamType;
 import org.eclipse.jetty.server.Request;
 
-import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PipedInputStream;
@@ -47,27 +46,27 @@ public class CameraStreamHandler extends CameraRequestHandler {
       // Get an inputstream from the distributer.
 
       PipedInputStream in = new PipedInputStream(distributer.getStream());
-      BufferedInputStream bs = new BufferedInputStream(in);
       OutputStream os = res.getOutputStream();
 
-      boolean sending = true;
-      while (bs.available() > -1 && sending) {
-        try {
-          os.write(bs.read());
-        } catch (IOException e) {
-          // An exception occured, this means the browser cannot be reached.
-          sending = false;
-        }
-      }
+      byte[] bytes = new byte[4096];
+      int bytesRead;
 
-      os.close();
-      bs.close();
-      in.close();
+      try {
+        while ((bytesRead = in.read(bytes)) != -1) {
+          os.write(bytes, 0, bytesRead);
+        }
+      } catch (Exception e) {
+        e.printStackTrace();
+      } finally {
+        os.close();
+        in.close();
+      }
 
     } else {
       res.setStatus(HttpServletResponse.SC_NOT_FOUND);
     }
 
+    System.out.println("TEST");
     request.setHandled(true);
   }
 

--- a/backend/src/main/java/com/benine/backend/http/HTTPServer.java
+++ b/backend/src/main/java/com/benine/backend/http/HTTPServer.java
@@ -10,9 +10,6 @@ import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.server.handler.ResourceHandler;
-import org.eclipse.jetty.util.log.StdErrLog;
-
-import java.util.Properties;
 
 /**
  * Class responsible for starting and mutating the HTTP Stream Server.
@@ -27,11 +24,6 @@ public class HTTPServer {
    * @throws Exception  If the server cannot be started, thus rendering the application useless.
    */
   public HTTPServer(int port) throws Exception {
-    // Disables Jetty Logging to a minimum.
-    Properties p = new Properties();
-    p.setProperty("org.eclipse.jetty.LEVEL", "WARN");
-    StdErrLog.setProperties(p);
-
     //The Jetty server object.
     this.server = new Server(port);
     setUpHandlers();

--- a/backend/src/main/java/com/benine/backend/video/MJPEGStreamReader.java
+++ b/backend/src/main/java/com/benine/backend/video/MJPEGStreamReader.java
@@ -36,7 +36,6 @@ public class MJPEGStreamReader extends StreamReader {
    * Creates a new MJPEGStreamReader.
    *
    * @param stream A stream object.
-   * @throws IOException If the inputstream cannot be read.
    */
   public MJPEGStreamReader(Stream stream) {
     this.bufferedStream = new BufferedInputStream(stream.getInputStream());
@@ -179,13 +178,14 @@ public class MJPEGStreamReader extends StreamReader {
    * @throws IOException If the bufferedstream cannot be read.
    */
   private byte[] readJPEG() throws IOException {
-    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    ByteArrayOutputStream jpeg = new ByteArrayOutputStream();
 
     while (!isJPEGTrailer()) {
-      baos.write(bufferedStream.read());
+      jpeg.write(bufferedStream.read());
     }
 
-    return baos.toByteArray();
+    jpeg.close();
+    return jpeg.toByteArray();
   }
 
   /**
@@ -201,6 +201,7 @@ public class MJPEGStreamReader extends StreamReader {
       header.write(bufferedStream.read());
     }
 
+    header.close();
     return header.toByteArray();
   }
 

--- a/backend/src/main/java/com/benine/backend/video/MJPEGStreamReader.java
+++ b/backend/src/main/java/com/benine/backend/video/MJPEGStreamReader.java
@@ -181,10 +181,8 @@ public class MJPEGStreamReader extends StreamReader {
     ByteArrayOutputStream jpeg = new ByteArrayOutputStream();
 
     while (!isJPEGTrailer()) {
-      int b = bufferedStream.read();
-
-      // If stream has not ended, add to header stream.
-      if (b != -1) {
+      // If stream has not ended, add to jpeg stream.
+      if (bufferedStream.available() != 0) {
         jpeg.write(bufferedStream.read());
       }
     }
@@ -203,10 +201,8 @@ public class MJPEGStreamReader extends StreamReader {
     ByteArrayOutputStream header = new ByteArrayOutputStream(128);
 
     while (!isJPEGHeader()) {
-      int b = bufferedStream.read();
-
       // If stream has not ended, add to header stream.
-      if (b != -1) {
+      if (bufferedStream.available() != 0) {
         header.write(bufferedStream.read());
       }
     }

--- a/backend/src/main/java/com/benine/backend/video/MJPEGStreamReader.java
+++ b/backend/src/main/java/com/benine/backend/video/MJPEGStreamReader.java
@@ -195,7 +195,7 @@ public class MJPEGStreamReader extends StreamReader {
    * @throws IOException if the header cannot be read from the buffered stream.
    */
   private byte[] getHeader() throws IOException {
-    ByteArrayOutputStream header = new ByteArrayOutputStream();
+    ByteArrayOutputStream header = new ByteArrayOutputStream(128);
 
     while (!isJPEGHeader()) {
       header.write(bufferedStream.read());

--- a/backend/src/main/java/com/benine/backend/video/MJPEGStreamReader.java
+++ b/backend/src/main/java/com/benine/backend/video/MJPEGStreamReader.java
@@ -181,7 +181,12 @@ public class MJPEGStreamReader extends StreamReader {
     ByteArrayOutputStream jpeg = new ByteArrayOutputStream();
 
     while (!isJPEGTrailer()) {
-      jpeg.write(bufferedStream.read());
+      int b = bufferedStream.read();
+
+      // If stream has not ended, add to header stream.
+      if (b != -1) {
+        jpeg.write(bufferedStream.read());
+      }
     }
 
     jpeg.close();
@@ -198,7 +203,12 @@ public class MJPEGStreamReader extends StreamReader {
     ByteArrayOutputStream header = new ByteArrayOutputStream(128);
 
     while (!isJPEGHeader()) {
-      header.write(bufferedStream.read());
+      int b = bufferedStream.read();
+
+      // If stream has not ended, add to header stream.
+      if (b != -1) {
+        header.write(bufferedStream.read());
+      }
     }
 
     header.close();

--- a/backend/src/main/java/com/benine/backend/video/Stream.java
+++ b/backend/src/main/java/com/benine/backend/video/Stream.java
@@ -33,7 +33,7 @@ public class Stream {
    */
   private void openConnection(URL streamURL) throws IOException {
     URLConnection conn = streamURL.openConnection();
-    conn.setConnectTimeout(1000);
+    conn.setConnectTimeout(5000);
 
     this.connection = conn;
   }

--- a/backend/src/test/java/com/benine/backend/http/RequestHandlerTest.java
+++ b/backend/src/test/java/com/benine/backend/http/RequestHandlerTest.java
@@ -74,13 +74,13 @@ public abstract class RequestHandlerTest {
   }
 
   public void setParameters(MultiMap<String> parameters) {
-    requestMock.setParameters(parameters);
+    requestMock.setQueryParameters(parameters);
 
     for (String s : parameters.keySet()) {
       when(requestMock.getParameter(s)).thenReturn(parameters.getString(s));
     }
 
-    when(requestMock.getParameters()).thenReturn(parameters);
+    when(requestMock.getQueryParameters()).thenReturn(parameters);
 
   }
 

--- a/frontend/modules/api.js
+++ b/frontend/modules/api.js
@@ -52,7 +52,15 @@ router.get('/getinfo', function (req, res) {
  * All /backend/... calls are rerouted to the backend server.
  */
 router.get('/backend/*', function (req, res) {
-    request(address + req.url.substring(8))
+    var apirequest = request(address + req.url.substring(8));
+
+    // If the connected client closes the connection, we should abort
+    // so the server knows it can stop streaming.
+    res.on('close', function() {
+        apirequest.abort();
+    });
+
+    apirequest
         .on('error', function (err) {
             // An error has occurred, most likely the server has not been started.
             if (err.code === 'ECONNREFUSED') {
@@ -60,7 +68,6 @@ router.get('/backend/*', function (req, res) {
             }
         })
         .pipe(res);
-
 });
 
 module.exports = router;


### PR DESCRIPTION
This should greatly improve the performance of the MJPEG streams.

It now reads the mjpeg in blocks instead of just looping over individual bytes for sending.
Also, now NodeJS stops the connection if the web client has disconnected. On a browser request the streams now properly close.