### PR TITLE
Preset queue controller

### DIFF
--- a/backend/src/main/java/com/benine/backend/ServerController.java
+++ b/backend/src/main/java/com/benine/backend/ServerController.java
@@ -3,6 +3,7 @@ package com.benine.backend;
 import com.benine.backend.camera.CameraController;
 import com.benine.backend.database.DatabaseController;
 import com.benine.backend.http.HTTPServer;
+import com.benine.backend.performance.PresetQueueController;
 import com.benine.backend.preset.PresetController;
 import com.benine.backend.video.StreamController;
 
@@ -26,6 +27,8 @@ public class ServerController {
   private static StreamController streamController;
   
   private static DatabaseController databaseController;
+  
+  private static PresetQueueController presetQueueController;
 
   private boolean running;
 
@@ -56,6 +59,8 @@ public class ServerController {
     cameraController = new CameraController();
 
     presetController = new PresetController();
+    
+    presetQueueController = new PresetQueueController();
   }
 
   /**
@@ -185,6 +190,15 @@ public class ServerController {
    */
   public PresetController getPresetController() {
     return presetController;
+  }
+  
+  /**
+   * Getter for presetQueueController
+   *
+   * @return Returns the presetQueueController.
+   */
+  public PresetQueueController getPresetQueueController() {
+    return presetQueueController;
   }
 
   /**

--- a/backend/src/main/java/com/benine/backend/performance/PresetQueue.java
+++ b/backend/src/main/java/com/benine/backend/performance/PresetQueue.java
@@ -64,4 +64,13 @@ public class PresetQueue {
   private int getLastValue() {
     return lastValue;
   }
+
+  public int getId() {
+    return 0;
+  }
+
+  public Object toJSON() {
+    // TODO Auto-generated method stub
+    return null;
+  }
 }

--- a/backend/src/main/java/com/benine/backend/performance/PresetQueue.java
+++ b/backend/src/main/java/com/benine/backend/performance/PresetQueue.java
@@ -10,6 +10,7 @@ public class PresetQueue {
   
   private int lastValue = 0;
   private LinkedHashMap<Integer,Preset> queue = new LinkedHashMap<Integer,Preset>();
+  private int id = -1;
   
   /**
    * Returns the presetQueue.
@@ -67,6 +68,10 @@ public class PresetQueue {
 
   public int getId() {
     return 0;
+  }
+  
+  public void setId(int id) {
+    this.id = id;
   }
 
   public Object toJSON() {

--- a/backend/src/main/java/com/benine/backend/performance/PresetQueueController.java
+++ b/backend/src/main/java/com/benine/backend/performance/PresetQueueController.java
@@ -1,0 +1,75 @@
+package com.benine.backend.performance;
+
+import com.benine.backend.LogEvent;
+import com.benine.backend.Logger;
+import com.benine.backend.ServerController;
+import com.benine.backend.camera.Camera;
+
+import java.util.ArrayList;
+
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+
+
+/**
+ * PresetQueue controller.
+ */
+public class PresetQueueController {
+  
+  private ArrayList<PresetQueue> presetQueues = new ArrayList<>();
+  
+  private Logger logger;
+  
+  private int highestIdInUse = 1;
+  
+  /**
+   * Constructs a Preset Queue controller.
+   */
+  public PresetQueueController() {
+    ServerController serverController = ServerController.getInstance();
+    logger = serverController.getLogger();
+  }
+  
+  /**
+   * Adds a new preset queue to this controller.
+   * @param presetQueue to add to this controller.
+   */
+  public void addPresetQueue(PresetQueue presetQueue) {
+    //presetQeueu.setId(highestIdInUse);
+    highestIdInUse++;
+    presetQueues.add(presetQueue);
+    logger.log("Added a new presetQueu with id: " + (highestIdInUse - 1), LogEvent.Type.INFO);
+  }
+  
+  /**
+   * Returns a JSON string of all preset queues.
+   * @return JSON string of all preset queues.
+   */
+  public String getPresetQueueJSON() {
+    JSONObject json = new JSONObject();
+    JSONArray array = new JSONArray();
+    for (PresetQueue presetQueue : getPresetQueues()) {
+      array.add(presetQueue.toJSON());
+    }
+    json.put("presetqueues", array);
+    return json.toJSONString();
+  }
+  
+  /**
+   * Finds the preset queue with the specified ID.
+   * @param id to find.
+   * @return preset queue with the specified id or null if it does not exist.
+   */
+  public PresetQueue getPresetQueueById(int id) {
+    for (PresetQueue p : presetQueues) {
+      if (p.getId() == id) {
+        return p;
+      }
+    }
+    return null;
+  }
+
+  public ArrayList<PresetQueue> getPresetQueues() {
+    return presetQueues;
+  }
+}

--- a/backend/src/main/java/com/benine/backend/performance/PresetQueueController.java
+++ b/backend/src/main/java/com/benine/backend/performance/PresetQueueController.java
@@ -3,12 +3,11 @@ package com.benine.backend.performance;
 import com.benine.backend.LogEvent;
 import com.benine.backend.Logger;
 import com.benine.backend.ServerController;
-import com.benine.backend.camera.Camera;
-
-import java.util.ArrayList;
 
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
+
+import java.util.ArrayList;
 
 
 /**
@@ -20,7 +19,7 @@ public class PresetQueueController {
   
   private Logger logger;
   
-  private int highestIdInUse = 1;
+  private static volatile int highestIdInUse = 1;
   
   /**
    * Constructs a Preset Queue controller.
@@ -35,10 +34,35 @@ public class PresetQueueController {
    * @param presetQueue to add to this controller.
    */
   public void addPresetQueue(PresetQueue presetQueue) {
-    presetQueue.setId(highestIdInUse);
-    highestIdInUse++;
+    presetQueue = addPresetQueueID(presetQueue);
     presetQueues.add(presetQueue);
-    logger.log("Added a new presetQueue with id: " + (highestIdInUse - 1), LogEvent.Type.INFO);
+    logger.log("Added a new presetQueue with id: " + presetQueue.getId(), LogEvent.Type.INFO);
+  }
+  
+  /**
+   * Adds a list of presetQueues to this controller.
+   * @param presetQueues list of presetQueues.
+   */
+  public void addPresetQueues(ArrayList<PresetQueue> presetQueues) {
+    for (PresetQueue p : presetQueues) {
+      addPresetQueue(p);
+    }
+  }
+  
+  /**
+   * Adds the right id to this presetqueue.
+   * @param presetQueue to add the id to.
+   * @return Presetqueue with right ID.
+   */
+  private static PresetQueue addPresetQueueID(PresetQueue presetQueue) {
+    if (presetQueue.getId() == -1) {
+      presetQueue.setId(PresetQueueController.highestIdInUse);
+      PresetQueueController.highestIdInUse++;
+    } else {
+      PresetQueueController.highestIdInUse = 
+              Math.max(PresetQueueController.highestIdInUse - 1, presetQueue.getId()) + 1;
+    }
+    return presetQueue;
   }
   
   /**

--- a/backend/src/main/java/com/benine/backend/performance/PresetQueueController.java
+++ b/backend/src/main/java/com/benine/backend/performance/PresetQueueController.java
@@ -35,10 +35,28 @@ public class PresetQueueController {
    * @param presetQueue to add to this controller.
    */
   public void addPresetQueue(PresetQueue presetQueue) {
-    //presetQeueu.setId(highestIdInUse);
+    presetQueue.setId(highestIdInUse);
     highestIdInUse++;
     presetQueues.add(presetQueue);
-    logger.log("Added a new presetQueu with id: " + (highestIdInUse - 1), LogEvent.Type.INFO);
+    logger.log("Added a new presetQueue with id: " + (highestIdInUse - 1), LogEvent.Type.INFO);
+  }
+  
+  /**
+   * removes the preset Queue from the list.
+   * @param presetQueue the presetQeueu to remove.
+   */
+  public void removePresetQueue(PresetQueue presetQueue) {
+    presetQueues.remove(presetQueue);
+  }
+  
+  /**
+   * Updates a presetQueue in the list.
+   * @param presetQueue the presetqueue to update.
+   */
+  public void updatePresetQueue(PresetQueue presetQueue) {
+    PresetQueue old = getPresetQueueById(presetQueue.getId());
+    presetQueues.remove(old);
+    presetQueues.add(presetQueue);
   }
   
   /**

--- a/backend/src/test/java/com/benine/backend/ServerControllerTest.java
+++ b/backend/src/test/java/com/benine/backend/ServerControllerTest.java
@@ -1,9 +1,5 @@
 package com.benine.backend;
 
-import com.benine.backend.camera.CameraController;
-import com.benine.backend.database.DatabaseController;
-import com.benine.backend.preset.PresetController;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;

--- a/backend/src/test/java/com/benine/backend/database/DatabaseControllerTest.java
+++ b/backend/src/test/java/com/benine/backend/database/DatabaseControllerTest.java
@@ -3,14 +3,12 @@ package com.benine.backend.database;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;

--- a/backend/src/test/java/com/benine/backend/performance/PresetQueueControllerTest.java
+++ b/backend/src/test/java/com/benine/backend/performance/PresetQueueControllerTest.java
@@ -41,12 +41,32 @@ public class PresetQueueControllerTest {
   }
   
   @Test
+  public void testAddPresetQueues() {  
+    ArrayList<PresetQueue> expected = new ArrayList<PresetQueue>();
+    expected.add(presetQueue1);
+    expected.add(presetQueue3);
+    presetQueueController.addPresetQueues(expected);
+    Assert.assertEquals(expected, presetQueueController.getPresetQueues());
+  }
+  
+  @Test
   public void testRemovePresetQueue() {  
     presetQueueController.addPresetQueue(presetQueue1);
     presetQueueController.addPresetQueue(presetQueue3);
     ArrayList<PresetQueue> expected = new ArrayList<PresetQueue>();
     expected.add(presetQueue1);
     presetQueueController.removePresetQueue(presetQueue3);
+    Assert.assertEquals(expected, presetQueueController.getPresetQueues());
+  }
+  
+  @Test
+  public void testUpdatePresetQueue() {  
+    presetQueueController.addPresetQueue(presetQueue3);
+    PresetQueue updatedPresetQueue = mock(PresetQueue.class);
+    when(updatedPresetQueue .getId()).thenReturn(3);
+    presetQueueController.updatePresetQueue(updatedPresetQueue );
+    ArrayList<PresetQueue> expected = new ArrayList<PresetQueue>();
+    expected.add(updatedPresetQueue);
     Assert.assertEquals(expected, presetQueueController.getPresetQueues());
   }
   
@@ -62,6 +82,12 @@ public class PresetQueueControllerTest {
   public void testgetPresetQueueById() {
     presetQueueController.addPresetQueue(presetQueue3);
     Assert.assertEquals(presetQueue3, presetQueueController.getPresetQueueById(3));
+  }
+  
+  @Test
+  public void testgetPresetQueueByIdNonExcisting() {
+    presetQueueController.addPresetQueue(presetQueue3);
+    Assert.assertEquals(null, presetQueueController.getPresetQueueById(5));
   }
   
   @Test

--- a/backend/src/test/java/com/benine/backend/performance/PresetQueueControllerTest.java
+++ b/backend/src/test/java/com/benine/backend/performance/PresetQueueControllerTest.java
@@ -1,5 +1,6 @@
 package com.benine.backend.performance;
 
+import java.io.File;
 import java.util.ArrayList;
 
 import org.json.simple.JSONArray;
@@ -7,6 +8,8 @@ import org.json.simple.JSONObject;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import com.benine.backend.ServerController;
 
 import static org.mockito.Mockito.*;
 
@@ -18,6 +21,8 @@ public class PresetQueueControllerTest {
   
   @Before
   public void setup() {
+    ServerController.setConfigPath("resources" + File.separator + "configs" + File.separator + "maintest.conf");
+    ServerController.getInstance();
     presetQueue1 = mock(PresetQueue.class);
     when(presetQueue1.getId()).thenReturn(-1);
     JSONObject json1 = new JSONObject();

--- a/backend/src/test/java/com/benine/backend/performance/PresetQueueControllerTest.java
+++ b/backend/src/test/java/com/benine/backend/performance/PresetQueueControllerTest.java
@@ -1,0 +1,79 @@
+package com.benine.backend.performance;
+
+import java.util.ArrayList;
+
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.*;
+
+public class PresetQueueControllerTest {
+  
+  PresetQueueController presetQueueController = new PresetQueueController();
+  PresetQueue presetQueue1;
+  PresetQueue presetQueue3;
+  
+  @Before
+  public void setup() {
+    presetQueue1 = mock(PresetQueue.class);
+    when(presetQueue1.getId()).thenReturn(-1);
+    JSONObject json1 = new JSONObject();
+    json1.put("id", 1);
+    json1.put("name", "testQueue");
+    when(presetQueue1.toJSON()).thenReturn(json1);
+    presetQueue3 = mock(PresetQueue.class);
+    when(presetQueue3.getId()).thenReturn(3);
+    JSONObject json3 = new JSONObject();
+    json3.put("id", 3);
+    json3.put("name", "testQueue");
+    when(presetQueue3.toJSON()).thenReturn(json3);
+  }
+  
+  @Test
+  public void testAddPresetQueue() {  
+    presetQueueController.addPresetQueue(presetQueue1);
+    ArrayList<PresetQueue> expected = new ArrayList<PresetQueue>();
+    expected.add(presetQueue1);
+    Assert.assertEquals(expected, presetQueueController.getPresetQueues());
+  }
+  
+  @Test
+  public void testRemovePresetQueue() {  
+    presetQueueController.addPresetQueue(presetQueue1);
+    presetQueueController.addPresetQueue(presetQueue3);
+    ArrayList<PresetQueue> expected = new ArrayList<PresetQueue>();
+    expected.add(presetQueue1);
+    presetQueueController.removePresetQueue(presetQueue3);
+    Assert.assertEquals(expected, presetQueueController.getPresetQueues());
+  }
+  
+  @Test
+  public void testAddPresetQueuewithID() {
+    presetQueueController.addPresetQueue(presetQueue3);
+    ArrayList<PresetQueue> expected = new ArrayList<PresetQueue>();
+    expected.add(presetQueue3);
+    Assert.assertEquals(expected, presetQueueController.getPresetQueues());
+  }
+  
+  @Test
+  public void testgetPresetQueueById() {
+    presetQueueController.addPresetQueue(presetQueue3);
+    Assert.assertEquals(presetQueue3, presetQueueController.getPresetQueueById(3));
+  }
+  
+  @Test
+  public void testgetPresetQueueJSON() {
+    presetQueueController.addPresetQueue(presetQueue1);
+    presetQueueController.addPresetQueue(presetQueue3);
+    JSONObject expected = new JSONObject();
+    JSONArray array = new JSONArray();
+    array.add(presetQueue1.toJSON());
+    array.add(presetQueue3.toJSON());
+    expected.put("presetqueues", array);
+    Assert.assertEquals(expected.toJSONString(), presetQueueController.getPresetQueueJSON());
+  }
+
+}


### PR DESCRIPTION
The presetQueueController class is used to store the different preset queues in the system.
It will assign an unique id to a preset queue when added and is able to create a json string of all preset queues in the controller.