### PR TITLE
Other name to newly added tag

### DIFF
--- a/frontend/public/js/presetcontroller.js
+++ b/frontend/public/js/presetcontroller.js
@@ -429,7 +429,7 @@ function deleteTag(index) {
 * Create a new tag.
 */
 function addTag() {
-	$(".fill-tags").prepend(appendEditable("tag" + localTags.length, true));
+	$(".fill-tags").prepend(appendEditable("tag " + localTags.length, true));
 	editTags(newId);
 	newId++;
 }

--- a/frontend/public/js/presetcontroller.js
+++ b/frontend/public/js/presetcontroller.js
@@ -429,7 +429,7 @@ function deleteTag(index) {
 * Create a new tag.
 */
 function addTag() {
-	$(".fill-tags").append(appendEditable("new", true));
+	$(".fill-tags").append(appendEditable("tag" + localTags.length, true));
 	editTags(newId);
 	newId++;
 }


### PR DESCRIPTION
When creating a new tag, the default first was "new", but it is changed to "tag" + index of new tag. I think this is better then first, but maybe someone has a better idea.