### PR TITLE
Direct add tag

### DIFF
--- a/frontend/public/js/presetcontroller.js
+++ b/frontend/public/js/presetcontroller.js
@@ -434,11 +434,10 @@ function updateTag(index, val) {
 		tagnames.initialize(true);
 		updateTagInPresets(remove, val);
 		$.get("/api/backend/presets/removetag?name=" + remove, function(data) {
-					console.log("create tag respone: " + data);
-		}).done();
-		$.get("/api/backend/presets/addtag?name=" + val, function(data) {
+			console.log("create tag respone: " + data);
+		}).done($.get("/api/backend/presets/addtag?name=" + val, function(data) {
 			console.log("create tag response: " + data);
-		}).done();
+		}).done());
 		return true;
 	}
 	return false;
@@ -479,12 +478,14 @@ function updateTagInPresets(old, fresh) {
 * Create a new tag.
 */
 function addTag() {
-	var add = "tag " + localTags.length;
-	$(".fill-tags").prepend(appendEditable(add, true));
-	newTag(add);
-	editable = false;
-	editTags(newId, true);
-	newId++;
+	if(editable) {
+		var add = "tag " + localTags.length;
+		$(".fill-tags").prepend(appendEditable(add, true));
+		newTag(add);
+		editable = false;
+		editTags(newId, true);
+		newId++;
+	}
 }
 
 /**

--- a/frontend/public/js/presetcontroller.js
+++ b/frontend/public/js/presetcontroller.js
@@ -365,44 +365,22 @@ function editTags(id, isNew) {
 			var tag = $('.new').val();
 			updateTag(id, tag);
 			$(this).parent().replaceWith(appendTag(id, tag));
-			console.log("update " + id + " " + newId);
 		}
 		else {
 			var tag = $('.new').val();
 			newTag(tag);
 			$(this).parent().replaceWith(appendTag(id, tag));
-			console.log("new " + id + " " + newId);
 		}
 	});
 	$(".delete").click(function(e){
 		e.preventDefault();
 		var tag = $('.new').val();
 		$(this).parent().remove();
-		if(isNew){
+		if(!isNew){
 			deleteTag(id);
-			console.log("delete " + id + " " + newId);
 		}
 	});
 }
-
-/**
-* Save the new tags in de array.
-*/
-function updateTags() {
-	for(i = 0; i < updatedTags.length; i++) {
-		if(localTags[updatedTags[i].index] != undefined){
-			//update tags
-			deleteTag(updatedTags[i].index);
-		}
-		//update/add tags
-		newTag(updatedTags[i].name);
-	}
-	//delete tags
-	for(i = 0; i < deleteTags.length; i++) {
-		deleteTag(deleteTags[i]);
-	}
-}
-
 
 /**
 * Function adds a new tag to the tag list.

--- a/frontend/public/js/presetcontroller.js
+++ b/frontend/public/js/presetcontroller.js
@@ -422,7 +422,7 @@ function deleteTag(index) {
 function updateTag(index, val) {
 	if ((localTags.indexOf(val) < 0 && val != "" && val != undefined) || localTags.indexOf(val) == index)  {
 		var remove = localTags[index];
-		localTags[index] = val
+		localTags[index] = val;
 		tagnames.clearPrefetchCache();
 		tagnames.initialize(true);
 		updateTagInPresets(remove, val);

--- a/frontend/public/js/presetcontroller.js
+++ b/frontend/public/js/presetcontroller.js
@@ -1,7 +1,5 @@
 // Local variable to store the available tags locally.
 var localTags = [];
-var deleteTags = [];
-var updatedTags = [];
 // true if the client is in preset editing mode.
 var editing = false;
 var searchTerm;
@@ -344,8 +342,6 @@ var newId = 0;
 * Load the tags modal en fill in the tags.
 */
 function loadTags() {
-	updatedTags = [];
-	deleteTags = [];
 	$(".fill-tags").empty();
 	$(".fill-tags").append(getTags());
 	newId = localTags.length;
@@ -355,26 +351,36 @@ $(".fill-tags").on('click', '.tag', function(e){
         e.preventDefault();
         var tag = $(this).html();
         $(this).replaceWith(appendEditable(tag, false));
-		editTags($(this).attr('id'));
+		editTags($(this).attr('id'), false);
 	});
 
 /**
 * Edit or delete a clicked on tag.
 * @id The id of the tag to edit
 */
-function editTags(id) {
+function editTags(id, isNew) {
 	$(".edit").click(function(e){
 		e.preventDefault();
-		var tag = $('.new').val();
-		$(this).parent().replaceWith(appendTag(id, tag));
-		updatedTags.push({index: id, name: tag});
+		if(!isNew) {
+			var tag = $('.new').val();
+			updateTag(id, tag);
+			$(this).parent().replaceWith(appendTag(id, tag));
+			console.log("update " + id + " " + newId);
+		}
+		else {
+			var tag = $('.new').val();
+			newTag(tag);
+			$(this).parent().replaceWith(appendTag(id, tag));
+			console.log("new " + id + " " + newId);
+		}
 	});
 	$(".delete").click(function(e){
 		e.preventDefault();
 		var tag = $('.new').val();
 		$(this).parent().remove();
-		if(id < newId){
-			deleteTags.push(id);
+		if(isNew){
+			deleteTag(id);
+			console.log("delete " + id + " " + newId);
 		}
 	});
 }
@@ -425,12 +431,25 @@ function deleteTag(index) {
 	}).done();
 }
 
+function updateTag(index, val) {
+	var remove = localTags[index];
+	localTags[index] = val
+	tagnames.clearPrefetchCache();
+ 	tagnames.initialize(true);
+	$.get("/api/backend/presets/removetag?name=" + remove, function(data) {
+				console.log("create tag respone: " + data);
+	}).done();
+	$.get("/api/backend/presets/addtag?name=" + val, function(data) {
+		console.log("create tag response: " + data);
+	}).done();
+}
+
 /**
 * Create a new tag.
 */
 function addTag() {
 	$(".fill-tags").append(appendEditable("tag" + localTags.length, true));
-	editTags(newId);
+	editTags(newId, true);
 	newId++;
 }
 

--- a/frontend/public/js/presetcontroller.js
+++ b/frontend/public/js/presetcontroller.js
@@ -417,7 +417,7 @@ function deleteTag(index) {
  	tagnames.initialize(true);
 	$.get("/api/backend/presets/removetag?name=" + remove, function(data) {
 				console.log("create tag respone: " + data);
-	}).done();
+	});
 }
 
 /**
@@ -431,12 +431,11 @@ function updateTag(index, val) {
 		localTags[index] = val;
 		tagnames.clearPrefetchCache();
 		tagnames.initialize(true);
-		updateTagInPresets(remove, val);
-		$.get("/api/backend/presets/removetag?name=" + remove, function(data) {
-			console.log("create tag respone: " + data);
-		}).done($.get("/api/backend/presets/addtag?name=" + val, function(data) {
-			console.log("create tag response: " + data);
-		}).done());
+		updateTagInPresets(remove, val, function() {
+			$.get("/api/backend/presets/removetag?name=" + remove, function(data) {
+				$.get("/api/backend/presets/addtag?name=" + val, function(data) {});
+			});
+		});
 		return true;
 	}
 	return false;
@@ -446,14 +445,15 @@ function updateTag(index, val) {
 * Updates a the tags in all the presets containing the old tag.
 * @param old The old tag
 * @param fresh The new tag
+* @param done callback
 */
-function updateTagInPresets(old, fresh) {
+function updateTagInPresets(old, fresh, done) {
 	for(i = 0; i < presets.length; i++) {
 		var tagIndex = presets[i].tags.indexOf(old);
 		if (tagIndex > -1) {
 			presets[i].tags[tagIndex] = fresh;
 			$.get("/api/backend/presets/edit?presetid=" + presets[i].id + "&overwritetag=true&overwriteposition=false&tags=" + presets[i].tags.join(","),
-																									function(data) {console.log("edit preset: " + data)});
+																									function(data) {console.log("edit preset: " + data); done();});
 		}
 	}
 }

--- a/frontend/public/js/presetcontroller.js
+++ b/frontend/public/js/presetcontroller.js
@@ -415,7 +415,6 @@ function deleteTag(index) {
 	localTags.splice(index,1);
 	tagnames.clearPrefetchCache();
  	tagnames.initialize(true);
-	deleteTagFromPresets(remove);
 	$.get("/api/backend/presets/removetag?name=" + remove, function(data) {
 				console.log("create tag respone: " + data);
 	}).done();
@@ -441,21 +440,6 @@ function updateTag(index, val) {
 		return true;
 	}
 	return false;
-}
-
-/**
-* Delete a the tags from all the presets containing the tag.
-* @param val The tag to be deleted
-*/
-function deleteTagFromPresets(val) {
-	for(i = 0; i < presets.length; i++) {
-		var tagIndex = presets[i].tags.indexOf(val);
-		if (tagIndex > -1) {
-			presets[i].tags.splice(tagIndex, 1);
-			$.get("/api/backend/presets/edit?presetid=" + presets[i].id + "&overwritetag=true&overwriteposition=false&tags=" + presets[i].tags.join(","),
-																									function(data) {console.log("edit preset: " + data)});
-		}
-	}
 }
 
 /**

--- a/frontend/public/js/presetcontroller.js
+++ b/frontend/public/js/presetcontroller.js
@@ -344,6 +344,7 @@ function findPresetOnID(id){
 
 //Below everything for the tag modal.
 var newId = 0;
+var editable = true;
 
 /**
 * Load the tags modal en fill in the tags.
@@ -352,14 +353,18 @@ function loadTags() {
 	$(".fill-tags").empty();
 	$(".fill-tags").append(getTags());
 	newId = localTags.length;
+	editable = true;
 }
 
 $(".fill-tags").on('click', '.tag', function(e){
+	if(editable) {
         e.preventDefault();
         var tag = $(this).html();
         $(this).replaceWith(appendEditable(tag, false));
+		editable = false;
 		editTags($(this).attr('id'), false);
-	});
+	}
+});
 
 /**
 * Edit or delete a clicked on tag.
@@ -373,12 +378,14 @@ function editTags(id, isNew) {
 		if (updated) {
 			$(this).parent().replaceWith(appendTag(id, tag));
 		}
+		editable = true;
 	});
 	$(".delete").click(function(e){
 		e.preventDefault();
 		var tag = $('.new').val();
 		$(this).parent().remove();
 		deleteTag(id);
+		editable = true;
 	});
 }
 
@@ -474,7 +481,8 @@ function updateTagInPresets(old, fresh) {
 function addTag() {
 	var add = "tag " + localTags.length;
 	$(".fill-tags").prepend(appendEditable(add, true));
-	newTag(add)
+	newTag(add);
+	editable = false;
 	editTags(newId, true);
 	newId++;
 }

--- a/frontend/views/partials/modals/edit-tags.ejs
+++ b/frontend/views/partials/modals/edit-tags.ejs
@@ -16,7 +16,7 @@
             <div class="modal-footer">
                 <button type="button" class="btn btn-primary pull-left" onclick="addTag()">Add</button>
                 <button type="button" class="btn btn-danger" data-dismiss="modal">Cancel</button>
-                <button type="button" class="btn btn-success" data-dismiss="modal" onclick="updateTags()"><span class="glyphicon glyphicon-floppy-disk"></span> Save & Close</button>
+                <button type="button" class="btn btn-success" data-dismiss="modal"><span class="glyphicon glyphicon-floppy-disk"></span> Save & Close</button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
This ensures that the tags are directly added, deleted and updated, instead of only when clicking on save&close.
This also ensures that the tags are correctly updated in the presets, when deleting and updating tags.