### PR TITLE
Fix wrong intial values tweak parameters autopreset

### DIFF
--- a/frontend/public/js/autopresets.js
+++ b/frontend/public/js/autopresets.js
@@ -10,6 +10,9 @@ var maxLevels = 3;
 * Executed when the modal for auto preset creation loads. Adds the mjpeg stream to the image behind the canvas.
 */
 $( ".auto-presets-modal").on("shown.bs.modal", function(e) {
+  $("#columns-amount").val(columns);
+  $("#rows-amount").val(rows);
+  $("#levels-amount").val(levels);
   var image = $("#auto-preset-creation-preview-image");
   var streamURL = '/api/backend/camera/' + currentcamera+ '/mjpeg?height='+image.height() + '&width='+image.width();
   $("#auto-preset-creation-preview-image").attr('src', streamURL);

--- a/frontend/views/partials/modals/auto-presets.ejs
+++ b/frontend/views/partials/modals/auto-presets.ejs
@@ -27,7 +27,7 @@
                           <div class="col-xs-6">
                             <div class="input-group">
                               <span class="input-group-addon label-auto-preset-input">Columns:</span>
-                              <input type="text" class="form-control" id="columns-amount" value="2" readonly/>
+                              <input type="text" class="form-control" id="columns-amount" value="3" readonly/>
                               <div class="input-group-btn">
                                 <button type="button" class="btn btn-default" onclick="increaseColumnAmount(-1)"><span data-bind="label" class="glyphicon glyphicon-minus"></span></button>
                                 <button type="button" class="btn btn-default" onclick="increaseColumnAmount(1)"><span data-bind="label" class="glyphicon glyphicon-plus"></span></button>
@@ -35,7 +35,7 @@
                             </div>
                             <div class="input-group">
                               <span class="input-group-addon label-auto-preset-input">Rows:</span>
-                              <input type="text" class="form-control" id="rows-amount" value="2" readonly/>
+                              <input type="text" class="form-control" id="rows-amount" value="3" readonly/>
                               <div class="input-group-btn">
                                 <button type="button" class="btn btn-default" onclick="increaseRowAmount(-1)"><span data-bind="label"  class="glyphicon glyphicon-minus"></span></button>
                                 <button type="button" class="btn btn-default" onclick="increaseRowAmount(1)"><span data-bind="label" class="glyphicon glyphicon-plus"></span></button>
@@ -43,7 +43,7 @@
                             </div>
                             <div class="input-group">
                               <span class="input-group-addon label-auto-preset-input">Levels:</span>
-                              <input type="text" class="form-control" id="levels-amount" value="2" readonly/>
+                              <input type="text" class="form-control" id="levels-amount" value="3" readonly/>
                               <div class="input-group-btn">
                                 <button type="button" class="btn btn-default" onclick="increaseLevelAmount(-1)"><span class="glyphicon glyphicon-minus"></span></button>
                                 <button type="button" class="btn btn-default" onclick="increaseLevelAmount(1)"><span class="glyphicon glyphicon-plus"></span></button>


### PR DESCRIPTION
The values indicating the amount of rows, columns and levels would show 2 when the actual value was 3 this updated after pressing a button. This fix should make sure they're correct when you open the modal.