### PR TITLE
Bower dependencies in separate file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,8 @@ jspm_packages
 
 # config files.
 *.json
+!frontend/package.json
+!frontend/bower.json
 
 # checkstyle files.
 .checkstyle

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Build the back-end server using `maven install` with the supplied `pom.xml` file
 
 ### Deployable zip
 #####Unix systems:
-Run the `install.sh` script, this generates a zip file, extract this zip file to the desired location on your system. The servers can then be started by executing the `install.sh` script.
+Run the `install.sh` script, this generates a zip file, extract this zip file to the desired location on your system. The servers can then be started by executing the `startserver.sh` script. If maven is not installed on your system, run the `other systems` install instructions. 
+
 #####Other systems:
 First, fetch the dependencies for the front-end server using `npm install`, then build the back-end server using `maven install` with the supplied `pom.xml` file. 
 The zip file containing the backend and frontend server can be found in the `backend/target` folder.

--- a/README.md
+++ b/README.md
@@ -16,14 +16,18 @@ Running the front-end server:
 ### Back end
 Build the back-end server using `maven install` with the supplied `pom.xml` file. 
 
-### Deployable zip
+### Build deployable zip
 #####Unix systems:
-Run the `install.sh` script, this generates a zip file, extract this zip file to the desired location on your system. The servers can then be started by executing the `startserver.sh` script. If maven is not installed on your system, run the `other systems` install instructions. 
+Run the `install.sh` script, this generates a zip file, extract this zip file to the desired location on your system. The servers can then be started by executing the `startserver.sh` script.
 
 #####Other systems:
 First, fetch the dependencies for the front-end server using `npm install`, then build the back-end server using `maven install` with the supplied `pom.xml` file. 
 The zip file containing the backend and frontend server can be found in the `backend/target` folder.
 When unzipped the backend and frontend server can both be started using the `startserver.cmd` batch file.
+
+### Run deployable zip
+If a zip file is distributed, or downloaded with a release this zip file should run out of the box.
+Depending on your system, run `startserver.sh` (Unix) or `startserver.cmd` (Windows).
 
 ## Tool results
 ### JavaScript

--- a/frontend/bower.json
+++ b/frontend/bower.json
@@ -1,0 +1,25 @@
+{
+  "name": "polycast-webinterface",
+  "description": "Web interface to communicate with the backend server controlling the cameras.",
+  "main": "app.js",
+  "license": "MIT",
+  "homepage": "https://github.com/Kingdorian/Contextproject-BeNine",
+  "private": true,
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "bootstrap-tagsinput": "^0.8.0",
+    "bootstrap-toggle": "^2.2.2",
+    "bootstrap": "^3.3.6",
+    "holderjs": "^2.9.3",
+    "js-cookie": "^2.1.2",
+    "hammerjs": "^2.0.8",
+    "nipplejs": "^0.6.3",
+    "typeahead.js": "^0.11.1"
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "scripts": {
     "test": "istanbul cover _mocha -- -u tdd",
-    "postinstall": "bower install bootstrap && bower install holderjs && bower install nipplejs && bower install hammerjs && bower install js-cookie && bower install bootstrap-tagsinput && bower install typeahead.js && bower install bootstrap-toggle"
+    "postinstall": "bower install"
   },
   "engines": {
     "node": ">=4.0.0"


### PR DESCRIPTION
I've moved the Bower dependencies to a `bower.json` file, where the dependencies belong originally. Please verify if `npm install` is still working correctly. 