### PR TITLE
Remove wrong responsd call in auto preset status handler

### DIFF
--- a/backend/src/main/java/com/benine/backend/http/AutoPresetCreationStatusHandler.java
+++ b/backend/src/main/java/com/benine/backend/http/AutoPresetCreationStatusHandler.java
@@ -39,11 +39,10 @@ public class AutoPresetCreationStatusHandler extends AutoPresetHandler  {
       object.put("amount_created", creator.getGeneratedPresetsAmount());
       object.put("amount_total", creator.getTotalAmountPresets());
       respond(request, httpServletResponse, object.toString());
-      AutoPresetCreationHandler.getCreators().get(cam.getId());
-      succes = true;
+    } else {
+      respond(request, httpServletResponse, succes);
     }
     AutoPresetCreationHandler.getCreators().remove(cam.getId());
-    respond(request, httpServletResponse, succes);
     request.setHandled(true);
   }
 


### PR DESCRIPTION
The auto preset status response is now correct.