### PR TITLE
Add address and camera type to /camera response

### DIFF
--- a/backend/src/main/java/com/benine/backend/camera/BasicCamera.java
+++ b/backend/src/main/java/com/benine/backend/camera/BasicCamera.java
@@ -21,14 +21,18 @@ public abstract class BasicCamera implements Camera {
   
   private long inUseTimeOut;
 
+  private String cameraType;
+
   /**
    * Constructor for a Basic Camera.
-   * @param type The streamType of this camera.
+   * @param streamType The streamType of this camera.
+   * @param cameraType The cameraType of this camera.
    */
-  public BasicCamera(StreamType type) {
+  public BasicCamera(String cameraType, StreamType streamType) {
     this.id = -1;
-    this.streamtype = type;
+    this.streamtype = streamType;
     this.inUse = false;
+    this.cameraType = cameraType;
   }
 
   /**
@@ -49,12 +53,19 @@ public abstract class BasicCamera implements Camera {
 
   /**
    * Get the ID of this camera.
-   * @return ID of this camra.
+   * @return ID of this camera.
    */
   public int getId() {
     return this.id;
   }
 
+  /**
+   * Get the camera type of this camera.
+   * @return ID of this camera.
+   */
+  public String getCameraType() {
+    return this.cameraType;
+  }
 
   /**
    * Get the Stream Type of this camera.

--- a/backend/src/main/java/com/benine/backend/camera/SimpleCamera.java
+++ b/backend/src/main/java/com/benine/backend/camera/SimpleCamera.java
@@ -20,7 +20,7 @@ public class SimpleCamera extends BasicCamera implements PresetCamera {
    * Defines a simple camera, which cannot be controlled.
    */
   public SimpleCamera() {
-    super(StreamType.MJPEG);
+    super("simplecamera", StreamType.MJPEG);
   }
 
   /**
@@ -32,6 +32,8 @@ public class SimpleCamera extends BasicCamera implements PresetCamera {
   public JSONObject toJSON() throws CameraConnectionException {
     JSONObject object = new JSONObject();
     object.put("id", getId());
+    object.put("type", getCameraType());
+    object.put("address", getStreamLink());
     object.put("inuse", isInUse());
     return object;
   }

--- a/backend/src/main/java/com/benine/backend/camera/SimpleCamera.java
+++ b/backend/src/main/java/com/benine/backend/camera/SimpleCamera.java
@@ -34,6 +34,7 @@ public class SimpleCamera extends BasicCamera implements PresetCamera {
     object.put("id", getId());
     object.put("type", getCameraType());
     object.put("address", getStreamLink());
+    object.put("streamaddress", getStreamLink());
     object.put("inuse", isInUse());
     return object;
   }

--- a/backend/src/main/java/com/benine/backend/camera/ipcameracontrol/IPCamera.java
+++ b/backend/src/main/java/com/benine/backend/camera/ipcameracontrol/IPCamera.java
@@ -445,7 +445,8 @@ public class IPCamera extends BasicCamera implements MovingCamera,
     JSONObject json = new JSONObject();
     json.put("id", this.getId());
     json.put("type", getCameraType());
-    json.put("address", getStreamLink());
+    json.put("address", ipaddress);
+    json.put("streamaddress", getStreamLink());
     json.put("inuse", isInUse());
     json.put("move", true);
     json.put("zoom", true);

--- a/backend/src/main/java/com/benine/backend/camera/ipcameracontrol/IPCamera.java
+++ b/backend/src/main/java/com/benine/backend/camera/ipcameracontrol/IPCamera.java
@@ -56,7 +56,7 @@ public class IPCamera extends BasicCamera implements MovingCamera,
    *  @param cameraController that controls this camera.
    */
   public IPCamera(String ip, CameraController cameraController) {
-    super(StreamType.MJPEG);
+    super("ipcamera", StreamType.MJPEG);
     ipaddress = ip;
     logger = cameraController.getLogger();
     config = cameraController.getConfig();
@@ -444,6 +444,8 @@ public class IPCamera extends BasicCamera implements MovingCamera,
     logger.log("JSON representation requested for camera " + getId(), LogEvent.Type.INFO);
     JSONObject json = new JSONObject();
     json.put("id", this.getId());
+    json.put("type", getCameraType());
+    json.put("address", getStreamLink());
     json.put("inuse", isInUse());
     json.put("move", true);
     json.put("zoom", true);

--- a/backend/src/test/java/com/benine/backend/camera/SimpleCameraTest.java
+++ b/backend/src/test/java/com/benine/backend/camera/SimpleCameraTest.java
@@ -46,6 +46,7 @@ public class SimpleCameraTest extends BasicCameraTest {
     expectedJSON.put("id", 3);
     expectedJSON.put("inuse", false);
     expectedJSON.put("address", "something");
+    expectedJSON.put("streamaddress", "something");
     expectedJSON.put("type", "simplecamera");
     Assert.assertEquals(expectedJSON, simpleCamera.toJSON());
   }

--- a/backend/src/test/java/com/benine/backend/camera/SimpleCameraTest.java
+++ b/backend/src/test/java/com/benine/backend/camera/SimpleCameraTest.java
@@ -1,15 +1,13 @@
 package com.benine.backend.camera;
 
+import com.benine.backend.video.StreamType;
+import org.json.simple.JSONObject;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.benine.backend.video.StreamType;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
-
-import org.json.simple.JSONObject;
 
 /**
  * Created on 5-5-16.
@@ -47,6 +45,8 @@ public class SimpleCameraTest extends BasicCameraTest {
     JSONObject expectedJSON = new JSONObject();
     expectedJSON.put("id", 3);
     expectedJSON.put("inuse", false);
+    expectedJSON.put("address", "something");
+    expectedJSON.put("type", "simplecamera");
     Assert.assertEquals(expectedJSON, simpleCamera.toJSON());
   }
   

--- a/backend/src/test/java/com/benine/backend/camera/ipcameracontrol/IpcameraTest.java
+++ b/backend/src/test/java/com/benine/backend/camera/ipcameracontrol/IpcameraTest.java
@@ -194,6 +194,8 @@ public class IpcameraTest extends BasicCameraTest {
     JSONObject json = new JSONObject();
     json.put("id", -1);
     json.put("inuse", false);
+    json.put("address", "http://test/cgi-bin/mjpeg");
+    json.put("type", "ipcamera");
     json.put("move", true);
     json.put("zoom", true);
     json.put("focus", true);

--- a/backend/src/test/java/com/benine/backend/camera/ipcameracontrol/IpcameraTest.java
+++ b/backend/src/test/java/com/benine/backend/camera/ipcameracontrol/IpcameraTest.java
@@ -194,7 +194,8 @@ public class IpcameraTest extends BasicCameraTest {
     JSONObject json = new JSONObject();
     json.put("id", -1);
     json.put("inuse", false);
-    json.put("address", "http://test/cgi-bin/mjpeg");
+    json.put("address", "test");
+    json.put("streamaddress", "http://test/cgi-bin/mjpeg");
     json.put("type", "ipcamera");
     json.put("move", true);
     json.put("zoom", true);


### PR DESCRIPTION
By request of team goto-fail, I've added the camera type and camera address to the `/camera` response. 
